### PR TITLE
fix compiler regression affecting IncludeExample.gb

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -142,8 +142,9 @@ task debugAll {
         println(rootProject.ext.get("libraryJarPath"))
         println(rootProject.ext.get("debugServerJarPath"))
         run {
-        args rootProject.ext.get("libraryJarPath"),
-            rootProject.ext.get("debugServerJarPath")
+            args rootProject.ext.get("libraryJarPath"),
+                rootProject.ext.get("debugServerJarPath")
+            // debug = true
         }
     }
 }

--- a/compiler/src/main/java/com/basic4gl/compiler/TomBasicCompiler.java
+++ b/compiler/src/main/java/com/basic4gl/compiler/TomBasicCompiler.java
@@ -5723,7 +5723,7 @@ public class TomBasicCompiler extends HasErrorState {
         Mutable<ValType> typeRef = new Mutable<>(type);
         Mutable<String> nameRef = new Mutable<>(name);
 
-        if (funcType == UserFunctionType.UFT_POINTER) {
+        if (funcType != UserFunctionType.UFT_POINTER) {
             // Note: Pointers to function types don't have a name.
             // Which also means they don't have anything to suffix with a data type.
             // (Return type can be declared after the function definition, with "as").


### PR DESCRIPTION
UFT_POINTER logic in compileUserFunction was mistranslated